### PR TITLE
Added support for SBx.x-1AV-40

### DIFF
--- a/sma-webconnect.html
+++ b/sma-webconnect.html
@@ -47,6 +47,7 @@
   <label for="node-input-device_selection"><i class="fa fa-gears"></i> Device</label>
   <select id="node-input-device_selection">
     <option selected value="sb_tripower">SB TRIPOWER 8.0/10.0</option>
+    <option value="sb">SB 3.0/3.6/4.0/5.0 (1AV-40)</option>
     <option value="sb_storage">SB STORAGE 2.5</option>
   </select>
 </div>

--- a/sma-webconnect.js
+++ b/sma-webconnect.js
@@ -48,8 +48,12 @@ module.exports = function (RED) {
         "name": "phase1_current",
         "divider": 1000
       },
+      "6400_0046C300": {
+        "name": "pv_gen_meter",
+        "divider": 1000
+      },
       "6100_0046C200": {
-        "name": "phase1_power",
+        "name": "power",
         "divider": 1
       }
     }

--- a/sma-webconnect.js
+++ b/sma-webconnect.js
@@ -33,6 +33,28 @@ module.exports = function (RED) {
     }
   };
 
+  const sb = {
+    "id": "1",
+    "values": {
+      "6100_00464800": {
+        "name": "phase1_voltage",
+        "divider": 100
+      },
+      "6100_00465700": {
+        "name": "frequency",
+        "divider": 100
+      },
+      "6100_40465300": {
+        "name": "phase1_current",
+        "divider": 1000
+      },
+      "6100_0046C200": {
+        "name": "phase1_power",
+        "divider": 1
+      }
+    }
+  };
+
   const sb_storage = {
     "id": "7",
     "values": {


### PR DESCRIPTION
### Purpose of PR
Adding support for the SMA SBx.x-1AV-40 series of inverters.

### Testing
Tested on Node-RED v1.2.6 with my SMA SB4.0-1AV-40 and SMA SB5.0-1AV-40 inverters.

Here is the output msg.payload:
`{"phase1_voltage":244.88,"frequency":49.95,"phase1_current":17.01,"phase1_power":4165,"available_sessions":1}`