### PR TITLE
Change the scope of the `message` var to local

### DIFF
--- a/sma-webconnect.js
+++ b/sma-webconnect.js
@@ -7,7 +7,6 @@ module.exports = function (RED) {
   // read presets on init
   devicePresets.readPresets();
   var deviceConfigs = devicePresets.getConfigs();
-  var message = {};
 
   function request(uri, body, callback) {
     retry({
@@ -67,6 +66,8 @@ module.exports = function (RED) {
 
   function getValues(node, callback, onSessionTimeout) {
     const url = buildUrl(node.use_tls, node.ip_address, "/dyn/getValues.json?sid=" + node.sid);
+
+    var message = {};
 
     // set default message according to device type
     if (node.use_custom_config) {


### PR DESCRIPTION
I did some investigation regarding https://github.com/rlindner/node-red-contrib-sma-webconnect/issues/22 and think I found the issue. What caught my interest is that all reporters on the issue were using at least two instances of this node in their flow and I thought there must be a problem with shared state.

The `message` var was defined "globally" in the scope of the exported function. And it appears that this function may only be called once from the runtime and then reused for all nodes. So I've just moved the `message` into the `getValues` function now, as there's no need for it to be defined outside of it.