### PR TITLE
Avoid TypeError when an invalid DeviceClassId is used

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -15,7 +15,7 @@ module.exports = {
         if (config.values.hasOwnProperty(key)) {
           const value = set[key];
 
-          if (value != null) {
+          if ((value != null) && (value[config.id] != null)) {
             var values = []; // value array
 
             // iterate over all elements in the message


### PR DESCRIPTION
This fixes a crash of node-red that I have seen today with my SMA Tripower8 SE device. Apparently, the value[config.id] was not iterable in one use of this function. I could not verify the final results, since my device is not yet connected to the public grid at this time (all values are still 0).